### PR TITLE
Stop plugin from stopping mobile user's music

### DIFF
--- a/src/ios/NativeAudio.m
+++ b/src/ios/NativeAudio.m
@@ -44,7 +44,7 @@ NSString* INFO_VOLUME_CHANGED = @"(NATIVE AUDIO) Volume changed.";
     }
 
     [session setActive: YES error: nil];
-    [session setCategory:AVAudioSessionCategoryPlayback error:nil];
+    [session setCategory:AVAudioSessionCategoryAmbient error:nil];
 }
 
 - (void) parseOptions:(NSDictionary*) options


### PR DESCRIPTION
This tweak means the plugin won't stop a person's music playing when they open the memberoo app.